### PR TITLE
Make the Maven Repository Server Plugin thread save

### DIFF
--- a/repository-hpi/pom.xml
+++ b/repository-hpi/pom.xml
@@ -107,7 +107,27 @@
             <artifactId>promoted-builds</artifactId>
             <version>2.10</version>
             <optional>true</optional>
+            <exclusions>
+	            <exclusion>
+	            	<groupId>org.mockito</groupId>
+					<artifactId>mockito-all</artifactId>
+	            </exclusion>
+            </exclusions>
         </dependency>
+        
+        <dependency>
+		    <groupId>org.hamcrest</groupId>
+		    <artifactId>hamcrest-all</artifactId>
+		    <version>1.3</version>
+		    <scope>test</scope>
+		 </dependency>
+		
+		 <dependency>
+		    <groupId>org.mockito</groupId>
+		    <artifactId>mockito-all</artifactId>
+		    <version>1.9.5</version>
+		    <scope>test</scope>
+		 </dependency>
 
         <dependency>
             <groupId>com.nirima.jenkins.repository</groupId>

--- a/repository-hpi/src/main/java/com/nirima/jenkins/repo/build/MetadataRepositoryItem.java
+++ b/repository-hpi/src/main/java/com/nirima/jenkins/repo/build/MetadataRepositoryItem.java
@@ -44,7 +44,7 @@ public class MetadataRepositoryItem extends TextRepositoryItem {
         // number seems to be always for the latest build, not the build that generated this
         // artifact; so we just use -1; it is essentially impossible that a project will be built
         // twice in the same millsecond, so there's no risk of collision
-        return _vfmt.format(date) + "-" + buildNo;
+        return new SimpleDateFormat(DAY_PATERN + "." + TIME_PATERN).format(date) + "-" + buildNo;
     }
 
     public static String formatDateVersion(Run buildRun) {
@@ -148,7 +148,7 @@ public class MetadataRepositoryItem extends TextRepositoryItem {
             String dateVers = formatDateVersion(theItem.getBuild());
 
             String itemVersion = version.replaceAll("SNAPSHOT", dateVers);
-            String lastMod = _ufmt.format(theItem.getLastModified());
+            String lastMod = new SimpleDateFormat(DAY_PATERN + TIME_PATERN).format(theItem.getLastModified());
             buf.append("      <snapshotVersion>\n");
 
             // Optional classifier.
@@ -173,6 +173,6 @@ public class MetadataRepositoryItem extends TextRepositoryItem {
         }
     }
 
-    protected static SimpleDateFormat _ufmt = new SimpleDateFormat("yyyyMMddHHmmss");
-    protected static SimpleDateFormat _vfmt = new SimpleDateFormat("yyyyMMdd.HHmmss");
+    private static final String DAY_PATERN = "yyyyMMdd";
+    private static final String TIME_PATERN = "HHmmss";
 }

--- a/repository-hpi/src/test/java/com/nirima/jenkins/repo/build/ConcurrentTestUtil.java
+++ b/repository-hpi/src/test/java/com/nirima/jenkins/repo/build/ConcurrentTestUtil.java
@@ -1,0 +1,73 @@
+package com.nirima.jenkins.repo.build;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.Iterables;
+class ConcurrentTestUtil {
+    public static void executeConcurrent(final String message, final Iterable<? extends Runnable> runnables, final int maxTimeoutSeconds) throws InterruptedException {
+        final Stopwatch stopWatch = new Stopwatch();
+        stopWatch.start();
+        final int numThreads = Iterables.size(runnables);
+        final List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<Throwable>());
+        final ExecutorService threadPool = Executors.newFixedThreadPool(numThreads);
+        try {
+            final CountDownLatch allExecutorThreadsReady = new CountDownLatch(numThreads);
+            final CountDownLatch afterInitBlocker = new CountDownLatch(1);
+            final CountDownLatch allDone = new CountDownLatch(numThreads);
+            for (final Runnable submittedTestRunnable : runnables) {
+                threadPool.submit(new TestRunnable(exceptions, allExecutorThreadsReady, afterInitBlocker, allDone, submittedTestRunnable));
+            }
+            // wait until all threads are ready
+            assertTrue("Timeout submitting Runnables to the ExecutorService",//
+                allExecutorThreadsReady.await((numThreads * 10) + 200, TimeUnit.MILLISECONDS));
+            // start all test runners
+            afterInitBlocker.countDown();
+            assertTrue(message + " timeout! More than " + maxTimeoutSeconds + "seconds", allDone.await(maxTimeoutSeconds, TimeUnit.SECONDS));
+            stopWatch.stop();
+        } finally {
+            threadPool.shutdownNow();
+        }
+        assertTrue(message + "failed with exception(s) " + exceptions, exceptions.isEmpty());
+        LoggerFactory.getLogger(ConcurrentTestUtil.class).info(message + " took " + stopWatch.elapsedTime(TimeUnit.MILLISECONDS) + "ms for " + numThreads);
+    }
+
+    private static final class TestRunnable implements Runnable {
+        private final List<Throwable> exceptions;
+        private final CountDownLatch allExecutorThreadsReady;
+        private final CountDownLatch afterInitBlocker;
+        private final CountDownLatch allDone;
+        private final Runnable submittedTestRunnable;
+
+        private TestRunnable(final List<Throwable> exceptions, final CountDownLatch allExecutorThreadsReady, final CountDownLatch afterInitBlocker, final CountDownLatch allDone,
+                final Runnable submittedTestRunnable) {
+            this.exceptions = exceptions;
+            this.allExecutorThreadsReady = allExecutorThreadsReady;
+            this.afterInitBlocker = afterInitBlocker;
+            this.allDone = allDone;
+            this.submittedTestRunnable = submittedTestRunnable;
+        }
+
+        public void run() {
+            allExecutorThreadsReady.countDown();
+            try {
+                afterInitBlocker.await();
+                submittedTestRunnable.run();
+            } catch (final Throwable e) {
+                exceptions.add(e);
+            } finally {
+                allDone.countDown();
+            }
+        }
+    }
+}

--- a/repository-hpi/src/test/java/com/nirima/jenkins/repo/build/MetadataRepositoryItemTest.java
+++ b/repository-hpi/src/test/java/com/nirima/jenkins/repo/build/MetadataRepositoryItemTest.java
@@ -1,0 +1,131 @@
+package com.nirima.jenkins.repo.build;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import hudson.maven.MavenBuild;
+import hudson.maven.MavenModule;
+import hudson.maven.reporters.MavenArtifact;
+import hudson.model.Run;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.Date;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.object.HasToString;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.common.collect.ImmutableList;
+@RunWith(MockitoJUnitRunner.class)
+public class MetadataRepositoryItemTest {
+    private Calendar refDate;
+    private MavenModule job = mock(MavenModule.class);
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder(new File("target"));
+
+    @Before
+    public void defineRefDate() {
+        refDate = Calendar.getInstance();
+        refDate.setTimeInMillis(61373977200000L);
+    }
+
+    @Before
+    public void stubJob() throws IOException {
+        job = mock(MavenModule.class);
+        when(job.getBuildDir()).thenReturn(folder.newFolder("repoItemTest"));
+    }
+
+    @Test
+    public void generateContent_oneEntry_asExpected() {
+        //arrange
+        final MavenBuild build = new MavenBuild(job, refDate);
+        final MavenArtifact artifact = new MavenArtifact("FOO", "BAR", "0.0.1-SNAPSHOT", "", "pom", "BAZ", "");
+        final MetadataRepositoryItem testee = new MetadataRepositoryItem(build, artifact);
+        final MavenArtifact artifactTest = new MavenArtifact("FOO", "BAR", "0.0.1-SNAPSHOT", "test", "pom", "BAZ", "");
+        final ArtifactRepositoryItem artifactRepositoryItem = mock(ArtifactRepositoryItem.class);
+        when(artifactRepositoryItem.getBuild()).thenReturn(build);
+        when(artifactRepositoryItem.getLastModified()).thenReturn(new Date(refDate.getTimeInMillis() + 8000));
+        testee.addArtifact(artifactTest, artifactRepositoryItem);
+        //act
+        final String generateContent = testee.generateContent();
+        //assert
+        final String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + //
+            "<metadata modelVersion=\"1.1.0\">\n" + //
+            "  <groupId>FOO</groupId>\n" + //
+            "  <artifactId>BAR</artifactId>\n" + //
+            "  <version>0.0.1-SNAPSHOT</version>\n" + //
+            "  <versioning>\n" + //
+            "    <snapshotVersions>\n" + //
+            "      <snapshotVersion>\n" + //
+            "        <classifier>test</classifier>\n" + //
+            "        <extension>pom</extension>\n" + //
+            "        <value>0.0.1-39141113.000000-0</value>\n" + //
+            "        <updated>39141113000008</updated>\n" + //
+            "      </snapshotVersion>\n" + //
+            "    </snapshotVersions>\n" + //
+            "  </versioning>\n" + //
+            "</metadata>\n";
+        assertEquals(expected, generateContent);
+    }
+
+    @Test
+    public void formatDateVersion_concurrent_alwaysRight() throws InterruptedException {
+        final FormatDateVersionActor actor0 = new FormatDateVersionActor(createRunWithOffset(0));
+        final FormatDateVersionActor actor1 = new FormatDateVersionActor(createRunWithOffset(1));
+        final FormatDateVersionActor actor2 = new FormatDateVersionActor(createRunWithOffset(2));
+        final FormatDateVersionActor actor3 = new FormatDateVersionActor(createRunWithOffset(3));
+        final FormatDateVersionActor actor4 = new FormatDateVersionActor(createRunWithOffset(4));
+        final FormatDateVersionActor actor5 = new FormatDateVersionActor(createRunWithOffset(5));
+        final FormatDateVersionActor actor6 = new FormatDateVersionActor(createRunWithOffset(6));
+        final FormatDateVersionActor actor7 = new FormatDateVersionActor(createRunWithOffset(7));
+        final FormatDateVersionActor actor8 = new FormatDateVersionActor(createRunWithOffset(8));
+        final FormatDateVersionActor actor9 = new FormatDateVersionActor(createRunWithOffset(9));
+        final Iterable<FormatDateVersionActor> allActors = ImmutableList.of(actor0, actor1, actor2, actor3, actor4, actor5, actor6, actor7, actor8, actor9);
+        //act
+        ConcurrentTestUtil.executeConcurrent("MetadataRepositoryItem#formatDateVersion should be threadsafe", allActors, 5);
+        //assert
+        assertThat(actor0, HasToString.<FormatDateVersionActor> hasToString(CoreMatchers.equalTo("39141113.000000-0")));
+        assertThat(actor1, HasToString.<FormatDateVersionActor> hasToString(CoreMatchers.equalTo("39141113.000001-0")));
+        assertThat(actor2, HasToString.<FormatDateVersionActor> hasToString(CoreMatchers.equalTo("39141113.000002-0")));
+        assertThat(actor3, HasToString.<FormatDateVersionActor> hasToString(CoreMatchers.equalTo("39141113.000003-0")));
+        assertThat(actor4, HasToString.<FormatDateVersionActor> hasToString(CoreMatchers.equalTo("39141113.000004-0")));
+        assertThat(actor5, HasToString.<FormatDateVersionActor> hasToString(CoreMatchers.equalTo("39141113.000005-0")));
+        assertThat(actor6, HasToString.<FormatDateVersionActor> hasToString(CoreMatchers.equalTo("39141113.000006-0")));
+        assertThat(actor7, HasToString.<FormatDateVersionActor> hasToString(CoreMatchers.equalTo("39141113.000007-0")));
+        assertThat(actor8, HasToString.<FormatDateVersionActor> hasToString(CoreMatchers.equalTo("39141113.000008-0")));
+        assertThat(actor9, HasToString.<FormatDateVersionActor> hasToString(CoreMatchers.equalTo("39141113.000009-0")));
+    }
+
+    private MavenBuild createRunWithOffset(final int offsetInSec) {
+        final Calendar refDate2 = Calendar.getInstance();
+        refDate2.setTimeInMillis(refDate.getTimeInMillis());
+        refDate2.add(Calendar.SECOND, offsetInSec);
+        final MavenBuild run2 = new MavenBuild(job, refDate2);
+        return run2;
+    }
+
+    private static class FormatDateVersionActor implements Runnable {
+        private final Run<?, ?> run;
+        private String formatedDate;
+
+        public FormatDateVersionActor(final Run<?, ?> run) {
+            this.run = run;
+        }
+
+        public void run() {
+            //act
+            formatedDate = MetadataRepositoryItem.formatDateVersion(run);
+        }
+
+        @Override
+        public String toString() {
+            return formatedDate;
+        }
+    }
+}


### PR DESCRIPTION
- Using this Plugin concurrent, results in wrong values in the
maven-metadata.xml
 - followed by checksum errors
 - followed by try to download inexisting artifacts 
- Added test for MetadataRepositoryItem
- Fixed use of SimpleDateFormat