### PR TITLE
[JENKINS-66324] Prepare Maven Repository Server for core Guava upgrade

### DIFF
--- a/repository-hpi/src/main/java/com/nirima/jenkins/repo/RootElement.java
+++ b/repository-hpi/src/main/java/com/nirima/jenkins/repo/RootElement.java
@@ -23,7 +23,6 @@
  */
 package com.nirima.jenkins.repo;
 
-import com.google.common.collect.Lists;
 import com.nirima.jenkins.repo.project.ProjectBuildList;
 import com.nirima.jenkins.repo.project.ProjectsElement;
 import com.nirima.jenkins.repo.virtual.AllSHA1RepositoryRoot;

--- a/repository-hpi/src/main/java/com/nirima/jenkins/repo/build/ProjectBuildRepositoryRoot.java
+++ b/repository-hpi/src/main/java/com/nirima/jenkins/repo/build/ProjectBuildRepositoryRoot.java
@@ -23,7 +23,6 @@
  */
 package com.nirima.jenkins.repo.build;
 
-import com.google.common.collect.Lists;
 import com.nirima.jenkins.repo.util.DirectoryPopulatorVisitor;
 import com.nirima.jenkins.repo.util.HudsonWalker;
 import com.nirima.jenkins.repo.util.IDirectoryPopulator;
@@ -64,18 +63,22 @@ public class ProjectBuildRepositoryRoot extends AbstractRepositoryDirectory impl
     }
 
     public Collection<? extends RepositoryElement> getChildren() {
-       return Lists.newArrayList(
+       List<RepositoryElement> result = new ArrayList<>();
+       result.add(
             new SimpleOnDemandItem(this,"repository", new IDirectoryPopulator() {
                 public void populate(DirectoryRepositoryItem directory) {
                     HudsonWalker.traverse(new DirectoryPopulatorVisitor(directory,false) ,item);
                 }
-            }),
+            })
+       );
+       result.add(
             new SimpleOnDemandItem(this,"repositoryChain", new IDirectoryPopulator() {
                 public void populate(DirectoryRepositoryItem directory) {
                     HudsonWalker.traverseChain(new DirectoryPopulatorVisitor(directory,false) ,item);
                 }
             })
        );
+       return result;
     }
 
     public String getDescription() {

--- a/repository-hpi/src/main/java/com/nirima/jenkins/repo/project/MultiBranchProjectElement.java
+++ b/repository-hpi/src/main/java/com/nirima/jenkins/repo/project/MultiBranchProjectElement.java
@@ -23,9 +23,6 @@
  */
 package com.nirima.jenkins.repo.project;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Iterators;
-import com.google.common.collect.Lists;
 import com.nirima.jenkins.repo.AbstractRepositoryDirectory;
 import com.nirima.jenkins.repo.RepositoryDirectory;
 import com.nirima.jenkins.repo.RepositoryElement;

--- a/repository-hpi/src/main/java/com/nirima/jenkins/repo/project/ProjectBuildList.java
+++ b/repository-hpi/src/main/java/com/nirima/jenkins/repo/project/ProjectBuildList.java
@@ -24,10 +24,6 @@
 
 package com.nirima.jenkins.repo.project;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import hudson.model.BuildableItemWithBuildWrappers;
 import hudson.model.Job;
 import hudson.model.Result;
@@ -40,7 +36,13 @@ import com.nirima.jenkins.repo.build.ProjectBuildRepositoryRoot;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class ProjectBuildList extends AbstractRepositoryDirectory implements RepositoryDirectory {
 
@@ -82,15 +84,13 @@ public class ProjectBuildList extends AbstractRepositoryDirectory implements Rep
                 }
             };
 
-            // Transform builds into items
-            Iterable<ProjectBuildRepositoryRoot> i = Iterables.transform(getJob().getBuilds(), fn);
-
-            // Remove NULL entries
-            return Lists.newArrayList(Iterables.filter(i, new Predicate<ProjectBuildRepositoryRoot>() {
-                public boolean apply(ProjectBuildRepositoryRoot projectBuildRepositoryRoot) {
-                    return projectBuildRepositoryRoot != null;
-                }
-            }));
+            List<? extends Run> runs = getJob().getBuilds();
+            return runs.stream()
+                    // Transform builds into items
+                    .map(fn)
+                    // Remove NULL entries
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
 
         } else {
 

--- a/repository-hpi/src/main/java/com/nirima/jenkins/repo/project/ProjectElement.java
+++ b/repository-hpi/src/main/java/com/nirima/jenkins/repo/project/ProjectElement.java
@@ -23,7 +23,6 @@
  */
 package com.nirima.jenkins.repo.project;
 
-import com.google.common.collect.Lists;
 import com.nirima.jenkins.repo.RepositoryElement;
 import com.nirima.jenkins.repo.build.ProjectBuildRepositoryRoot;
 import hudson.model.BuildableItemWithBuildWrappers;
@@ -31,6 +30,7 @@ import com.nirima.jenkins.repo.AbstractRepositoryDirectory;
 import com.nirima.jenkins.repo.RepositoryDirectory;
 import hudson.model.Job;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -51,10 +51,9 @@ public class ProjectElement extends AbstractRepositoryDirectory implements Repos
 
     public @Override Collection<? extends RepositoryElement> getChildren() {
 
-        List ar =  Lists.newArrayList(
-                new ProjectBuildList(this, item, ProjectBuildList.Type.SHA1),
-                new ProjectBuildList(this, item, ProjectBuildList.Type.Build)
-        );
+        List<RepositoryElement> ar = new ArrayList<>();
+        ar.add(new ProjectBuildList(this, item, ProjectBuildList.Type.SHA1));
+        ar.add(new ProjectBuildList(this, item, ProjectBuildList.Type.Build));
 
         if( item.getLastSuccessfulBuild() != null ) {
             ar.add( new ProjectBuildRepositoryRoot(this, item.getLastSuccessfulBuild(), "LastSuccessful") );

--- a/repository-hpi/src/main/java/com/nirima/jenkins/repo/project/ProjectUtils.java
+++ b/repository-hpi/src/main/java/com/nirima/jenkins/repo/project/ProjectUtils.java
@@ -1,10 +1,5 @@
 package com.nirima.jenkins.repo.project;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.Iterators;
-import com.google.common.collect.Lists;
 import com.nirima.jenkins.repo.RepositoryDirectory;
 import com.nirima.jenkins.repo.RepositoryElement;
 import hudson.model.BuildableItem;
@@ -15,7 +10,9 @@ import jenkins.branch.MultiBranchProject;
 import jenkins.model.Jenkins;
 
 import java.util.Collection;
-import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Created by magnayn on 12/10/2015.
@@ -23,7 +20,7 @@ import java.util.List;
 public class ProjectUtils {
 
     public static Collection<RepositoryElement> getChildren(final RepositoryDirectory parent, final Collection<?> items) {
-        List<RepositoryElement> elements = Lists.newArrayList(Iterators.transform(items.iterator(),
+        return items.stream().map(
                 new Function<Object, RepositoryElement>() {
                     public RepositoryElement apply(Object from) {
                         if (from instanceof BuildableItemWithBuildWrappers) {
@@ -38,15 +35,10 @@ public class ProjectUtils {
 
                         return null;
                     }
-                }));
-
-        // Squash ones we couldn't sensibly find an element for.
-        return Collections2.filter(elements, new Predicate<RepositoryElement>() {
-            @Override
-            public boolean apply(RepositoryElement input) {
-                return input != null;
-            }
-        });
+                })
+                // Squash ones we couldn't sensibly find an element for.
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     public static String sanitizeName(String name) {

--- a/repository-hpi/src/main/java/com/nirima/jenkins/repo/project/ProjectsElement.java
+++ b/repository-hpi/src/main/java/com/nirima/jenkins/repo/project/ProjectsElement.java
@@ -23,11 +23,6 @@
  */
 package com.nirima.jenkins.repo.project;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.Iterators;
-import com.google.common.collect.Lists;
 import com.nirima.jenkins.repo.AbstractRepositoryDirectory;
 import hudson.maven.MavenModule;
 import hudson.model.BuildableItem;
@@ -42,6 +37,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public class ProjectsElement extends AbstractRepositoryDirectory implements RepositoryDirectory {
     public ProjectsElement(RepositoryDirectory parent) {
@@ -57,9 +54,9 @@ public class ProjectsElement extends AbstractRepositoryDirectory implements Repo
     public Collection<RepositoryElement> getChildren() {
 
         return ProjectUtils.getChildren(this,
-                Collections2.filter(Jenkins.getInstance().getAllItems(BuildableItem.class), new Predicate<BuildableItem>() {
+                Jenkins.getInstance().getAllItems(BuildableItem.class).stream().filter(new Predicate<BuildableItem>() {
                     @Override
-                    public boolean apply(@Nullable BuildableItem input) {
+                    public boolean test(@Nullable BuildableItem input) {
                         if( input == null )
                             return false;
 
@@ -72,7 +69,7 @@ public class ProjectsElement extends AbstractRepositoryDirectory implements Repo
 
                         return false;
                     }
-                }));
+                }).collect(Collectors.toList()));
 
     }
 

--- a/repository-hpi/src/main/java/com/nirima/jenkins/repo/util/DirectoryPopulatorVisitor.java
+++ b/repository-hpi/src/main/java/com/nirima/jenkins/repo/util/DirectoryPopulatorVisitor.java
@@ -23,7 +23,6 @@
  */
 package com.nirima.jenkins.repo.util;
 
-import com.google.common.base.Joiner;
 import com.nirima.jenkins.repo.RepositoryContent;
 import com.nirima.jenkins.repo.build.ArtifactRepositoryItem;
 import com.nirima.jenkins.repo.build.DirectoryRepositoryItem;
@@ -71,7 +70,7 @@ public class DirectoryPopulatorVisitor extends HudsonVisitor {
     }
 
     public String getDescription() {
-        return Joiner.on("->").join(listOfProjectNames);
+        return String.join("->", listOfProjectNames);
     }
 
     public @Override void visitArtifact(Run build, MavenArtifact artifact)

--- a/repository-hpi/src/main/java/com/nirima/jenkins/repo/util/HudsonVisitor.java
+++ b/repository-hpi/src/main/java/com/nirima/jenkins/repo/util/HudsonVisitor.java
@@ -23,7 +23,6 @@
  */
 package com.nirima.jenkins.repo.util;
 
-import com.google.common.collect.Lists;
 import com.nirima.jenkins.repo.RepositoryElement;
 import com.nirima.jenkins.repo.build.ArtifactRepositoryItem;
 import hudson.maven.MavenBuild;

--- a/repository-hpi/src/main/java/com/nirima/jenkins/repo/util/HudsonWalker.java
+++ b/repository-hpi/src/main/java/com/nirima/jenkins/repo/util/HudsonWalker.java
@@ -23,10 +23,6 @@
  */
 package com.nirima.jenkins.repo.util;
 
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-
 import com.nirima.jenkins.action.ProjectRepositoryAction;
 import com.nirima.jenkins.action.RepositoryAction;
 import com.nirima.jenkins.update.RepositoryArtifactRecord;
@@ -45,6 +41,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
 
 /**
  * Created by IntelliJ IDEA.
@@ -115,11 +113,12 @@ public class HudsonWalker {
                 AbstractProject item = (AbstractProject)Hudson.getInstance().getItem(projectRepositoryAction.getProjectName());
 
 
-                Optional<Run> r = Iterables.tryFind(item.getBuilds(), new Predicate<Run>() {
-                    public boolean apply(Run run) {
+                List<? extends Run> runs = item.getBuilds();
+                Optional<Run> r = runs.stream().filter(new Predicate<Run>() {
+                    public boolean test(Run run) {
                         return run.getNumber() == projectRepositoryAction.getBuildNumber();
                     }
-                });
+                }).map(Run.class::cast).findAny();
 
                 if( r.isPresent() )
                     traverseChain(visitor, r.get());

--- a/repository-hpi/src/main/java/com/nirima/jenkins/token/RepositoryTokenMacro.java
+++ b/repository-hpi/src/main/java/com/nirima/jenkins/token/RepositoryTokenMacro.java
@@ -23,7 +23,6 @@
  */
 package com.nirima.jenkins.token;
 
-import com.google.common.collect.ListMultimap;
 import hudson.Extension;
 import hudson.model.*;
 import org.jenkinsci.plugins.tokenmacro.DataBoundTokenMacro;

--- a/repository-hpi/src/main/java/com/nirima/jenkins/update/RepositoryArtifactRecord.java
+++ b/repository-hpi/src/main/java/com/nirima/jenkins/update/RepositoryArtifactRecord.java
@@ -1,7 +1,5 @@
 package com.nirima.jenkins.update;
 
-import com.google.common.base.Objects;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -95,13 +93,19 @@ public class RepositoryArtifactRecord implements Serializable {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-        .add("attachedArtifacts", attachedArtifacts)
-        .add("mainArtifact", mainArtifact)
-        .add("pomArtifact", pomArtifact)
-        .add("repositoryUrl", repositoryUrl)
-        .add("repositoryId", repositoryId)
-        .add("fileMap", fileMap)
-        .toString();
+    return "RepositoryArtifactRecord{"
+        + "attachedArtifacts={"
+        + attachedArtifacts
+        + "}, mainArtifact="
+        + mainArtifact
+        + ", pomArtifact="
+        + pomArtifact
+        + ", repositoryUrl="
+        + repositoryUrl
+        + ", repositoryId="
+        + repositoryId
+        + ", fileMap={"
+        + fileMap
+        + "}}";
   }
 }

--- a/repository-hpi/src/main/java/com/nirima/jenkins/webdav/impl/methods/Get.java
+++ b/repository-hpi/src/main/java/com/nirima/jenkins/webdav/impl/methods/Get.java
@@ -22,7 +22,6 @@
  * THE SOFTWARE.
  */
 package com.nirima.jenkins.webdav.impl.methods;
-import com.google.common.io.ByteStreams;
 import com.nirima.jenkins.webdav.interfaces.*;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
@@ -52,7 +51,7 @@ public class Get extends Head {
 
             long start = System.currentTimeMillis();
 
-            long bytes = ByteStreams.copy(is, os);
+            long bytes = IOUtils.copy(is, os);
             os.flush();
 
             long duration = System.currentTimeMillis() - start;


### PR DESCRIPTION
See [JENKINS-66324](https://issues.jenkins.io/browse/JENKINS-66324) and [JENKINS-65988](https://issues.jenkins.io/browse/JENKINS-65988). Jenkins core is using [Guava 11.0.1](https://github.com/google/guava/releases/tag/v11.0.1), which was released on January 9, 2012. Jenkins core would like to upgrade to [Guava 30.1.1](https://github.com/google/guava/releases/tag/v30.1.1), which was released on March 19, 2021. Plugins must be prepared to be compatible with both Guava 11.0.1 and Guava 30.1.1 in advance of this core transition.

In particular, this plugin has been identified as using the `com.google.common.base.Objects#toStringHelper` method, which existed in Guava [11.0.1](https://guava.dev/releases/11.0.1/api/docs/com/google/common/base/Objects.html) but was [removed in later versions](https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/base/Objects.html).

To facilitate the Jenkins core transition, this plugin must be prepared and released such that it works with both Guava 11.0.1 and latest. This PR migrates away from `Objects#toStringHelper` and rewrites the code to use the native functionality provided by the Java Platform.

CC @magnayn